### PR TITLE
Typo: Day 1 delete 'ruby'

### DIFF
--- a/summer-of-code/week-01/day1.md
+++ b/summer-of-code/week-01/day1.md
@@ -80,7 +80,7 @@ Open your text editor, and type the following:
 print(1+2)
 ```
 
-Save your program (yep, that’s a complete program!) as `calc.py`. Now run your program by typing ruby `calc.py` into your command line. 
+Save your program (yep, that’s a complete program!) as `calc.py`. Now run your program by typing `calc.py` into your command line. 
 
 It should put a 3 on your screen. 
 


### PR DESCRIPTION
Noticed a typo in line 83 where it mentions ruby.