### PR TITLE
Update README.md

### DIFF
--- a/summer-of-code/README.md
+++ b/summer-of-code/README.md
@@ -452,7 +452,7 @@ Using the [Advanced JavaScript](https://github.com/advanced-js/syllabus#course-o
 
 August 27 - 31    Mobile Prototyping (UI/UX) in InvisionApp
 
-Using Invision's [Getting Started](https://github.com/advanced-js/syllabus#course-outline) guides.
+Using Invision's [Getting Started](https://support.invisionapp.com/hc/en-us/categories/115000098263-Getting-Started) guides.
 
 1. Introduction to InvisionApp
 1. Boards


### PR DESCRIPTION
Fix Week 7, Using Invision's [Getting Started] link. It currently points to Advanced JavaScript course.